### PR TITLE
Scrollbar styles are not working on Firefox #3

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,6 +100,7 @@ textarea {
   resize: none;
   border: none;
   font-size: 0.9rem;
+  min-height: 0; /* This fixes the problem if textarea not resizing in Firefox */
 }
 textarea:focus {
   outline: none;
@@ -230,4 +231,18 @@ textarea:focus {
     transparent 75%,
     transparent
   );
+}
+
+/* Styles for the scrollbars in Firefox */
+html {
+  scrollbar-color: #f90 transparent;
+  scrollbar-width: thin;
+}
+
+.scrollBarOrangeTransparent {
+  scrollbar-color: #f90 transparent;
+}
+
+.thinScrollbar {
+  scrollbar-width: thin;
 }

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -33,7 +33,7 @@ const Notes = ({ addNote, noteItems, deleteNote }) => {
     });
   }
   return (
-    <div className="notes-container">
+    <div className="notes-container scrollBarOrangeTransparent thinScrollbar">
       <CreateNote add={addNote} />
       {notesElements}
       <ModalNote


### PR DESCRIPTION
This pull request also includes the solution to the issue -> [Textarea not shrinking after adding notes in Firefox #4](https://github.com/lotfijb/bullet-journal-extension/issues/4)